### PR TITLE
Optimistic proposal ID format

### DIFF
--- a/src/OptimisticTokenVotingPlugin.sol
+++ b/src/OptimisticTokenVotingPlugin.sol
@@ -75,10 +75,6 @@ contract OptimisticTokenVotingPlugin is
     bytes32 public constant UPDATE_OPTIMISTIC_GOVERNANCE_SETTINGS_PERMISSION_ID =
         keccak256("UPDATE_OPTIMISTIC_GOVERNANCE_SETTINGS_PERMISSION");
 
-    /// @notice The [ERC-165](https://eips.ethereum.org/EIPS/eip-165) interface ID of the contract.
-    bytes4 public constant OPTIMISTIC_GOVERNANCE_INTERFACE_ID =
-        this.initialize.selector ^ this.getProposal.selector ^ this.updateOptimisticGovernanceSettings.selector;
-
     /// @notice An [OpenZeppelin `Votes`](https://docs.openzeppelin.com/contracts/4.x/api/governance#Votes) compatible contract referencing the token being used for voting.
     IVotesUpgradeable public votingToken;
 

--- a/test/EmergencyMultisig.t.sol
+++ b/test/EmergencyMultisig.t.sol
@@ -1542,7 +1542,8 @@ contract EmergencyMultisigTest is AragonTest {
         vm.expectEmit();
         emit Executed(pid);
         vm.expectEmit();
-        emit ProposalCreated(0, address(plugin), 10, 10, "", actions, 0);
+        uint256 targetPid = 10 << 128 | 10 << 64;
+        emit ProposalCreated(targetPid, address(plugin), 10, 10, "", actions, 0);
         plugin.execute(pid, actions);
 
         // 2
@@ -1573,7 +1574,8 @@ contract EmergencyMultisigTest is AragonTest {
         vm.expectEmit();
         emit Executed(pid);
         vm.expectEmit();
-        emit ProposalCreated(1, address(plugin), 20, 20, "ipfs://", actions, 0);
+        targetPid = (20 << 128 | 20 << 64) + 1;
+        emit ProposalCreated(targetPid, address(plugin), 20, 20, "ipfs://", actions, 0);
         plugin.execute(pid, actions);
     }
 
@@ -1938,7 +1940,9 @@ contract EmergencyMultisigTest is AragonTest {
         plugin.execute(pid, submittedActions);
 
         // Check round
-        (open, executed, parameters, vetoTally, retrievedActions, allowFailureMap) = optimisticPlugin.getProposal(pid);
+        uint256 targetPid = (uint256(block.timestamp) << 128 | uint256(block.timestamp) << 64);
+        (open, executed, parameters, vetoTally, retrievedActions, allowFailureMap) =
+            optimisticPlugin.getProposal(targetPid);
 
         assertEq(open, false, "Should not be open");
         assertEq(executed, true, "Should be executed");
@@ -1987,7 +1991,9 @@ contract EmergencyMultisigTest is AragonTest {
         plugin.execute(pid, submittedActions);
 
         // Check round
-        (open, executed, parameters, vetoTally, retrievedActions, allowFailureMap) = optimisticPlugin.getProposal(pid);
+        targetPid = (uint256(block.timestamp) << 128 | uint256(block.timestamp) << 64) + 1;
+        (open, executed, parameters, vetoTally, retrievedActions, allowFailureMap) =
+            optimisticPlugin.getProposal(targetPid);
 
         assertEq(open, false, "Should not be open");
         assertEq(executed, true, "Should be executed");

--- a/test/Multisig.t.sol
+++ b/test/Multisig.t.sol
@@ -2748,9 +2748,10 @@ contract MultisigTest is AragonTest {
         // event
         vm.expectEmit();
         emit Executed(pid);
+        uint256 targetPid = uint256(block.timestamp) << 128 | uint256(block.timestamp + 4 days) << 64;
         vm.expectEmit();
         emit ProposalCreated(
-            0,
+            targetPid,
             address(plugin),
             uint64(block.timestamp),
             uint64(block.timestamp) + 4 days,
@@ -2792,9 +2793,10 @@ contract MultisigTest is AragonTest {
         // events
         vm.expectEmit();
         emit Executed(pid);
+        targetPid = (uint256(block.timestamp + 10 days) << 128 | uint256(block.timestamp + 50 days) << 64) + 1;
         vm.expectEmit();
         emit ProposalCreated(
-            1,
+            targetPid,
             address(plugin),
             10 days,
             50 days,
@@ -2888,9 +2890,11 @@ contract MultisigTest is AragonTest {
         emit Approved(pid, carol);
         vm.expectEmit();
         emit Executed(pid);
+
+        uint256 targetPid = (uint256(block.timestamp) << 128 | uint256(block.timestamp + 4 days) << 64);
         vm.expectEmit();
         emit ProposalCreated(
-            0, // foreign pid
+            targetPid,
             address(plugin),
             uint64(block.timestamp),
             uint64(block.timestamp) + 4 days,
@@ -2931,9 +2935,11 @@ contract MultisigTest is AragonTest {
         emit Approved(pid, carol);
         vm.expectEmit();
         emit Executed(pid);
+
+        targetPid = (uint256(5 days) << 128 | uint256(20 days) << 64) + 1;
         vm.expectEmit();
         emit ProposalCreated(
-            1, // foreign pid
+            targetPid, // foreign pid
             address(plugin),
             5 days,
             20 days,
@@ -2974,9 +2980,11 @@ contract MultisigTest is AragonTest {
         emit Approved(pid, carol);
         vm.expectEmit();
         emit Executed(pid);
+
+        targetPid = (uint256(3 days) << 128 | uint256(500 days) << 64) + 2;
         vm.expectEmit();
         emit ProposalCreated(
-            2, // foreign pid
+            targetPid,
             address(plugin),
             3 days,
             500 days,
@@ -3733,6 +3741,7 @@ contract MultisigTest is AragonTest {
         plugin.execute(pid);
 
         // Check round
+        uint targetPid = uint256(4 days) << 64; // start=0, end=4d, counter=0
         (
             open,
             executed,
@@ -3740,7 +3749,7 @@ contract MultisigTest is AragonTest {
             vetoTally,
             actions,
             allowFailureMap
-        ) = optimisticPlugin.getProposal(pid);
+        ) = optimisticPlugin.getProposal(targetPid);
 
         assertEq(open, true, "Should be open");
         assertEq(executed, false, "Should not be executed");
@@ -3800,6 +3809,7 @@ contract MultisigTest is AragonTest {
         plugin.execute(pid);
 
         // Check round
+        targetPid = (uint256(block.timestamp + 1 days) << 128 | uint256(block.timestamp + 6 days) << 64) + 1;
         (
             open,
             executed,
@@ -3807,7 +3817,7 @@ contract MultisigTest is AragonTest {
             vetoTally,
             actions,
             allowFailureMap
-        ) = optimisticPlugin.getProposal(pid);
+        ) = optimisticPlugin.getProposal(targetPid);
 
         assertEq(open, false, "Should not be open");
         assertEq(executed, false, "Should not be executed");

--- a/test/OptimisticTokenVotingPlugin.t.sol
+++ b/test/OptimisticTokenVotingPlugin.t.sol
@@ -159,7 +159,7 @@ contract OptimisticTokenVotingPluginTest is AragonTest {
         supported = plugin.supportsInterface(bytes4(0xffffffff));
         assertEq(supported, false, "Should not support any other interface");
 
-        // Certain fuzzing values are expected to be true
+        // Skip the values that can be true
         if (
             _randomInterfaceId == type(IERC165Upgradeable).interfaceId
                 || _randomInterfaceId == type(IPlugin).interfaceId || _randomInterfaceId == type(IProposal).interfaceId
@@ -167,8 +167,6 @@ contract OptimisticTokenVotingPluginTest is AragonTest {
                 || _randomInterfaceId == type(IOptimisticTokenVoting).interfaceId
                 || _randomInterfaceId == type(IMembership).interfaceId
         ) {
-            supported = plugin.supportsInterface(_randomInterfaceId);
-            assertEq(supported, true, "Interface should be supported");
             return;
         }
 

--- a/test/base/AragonTest.sol
+++ b/test/base/AragonTest.sol
@@ -70,6 +70,12 @@ contract AragonTest is Test {
             )
         );
 
+        // The plugin can execute on the DAO
+        dao.grant(address(dao), address(optimisticPlugin), dao.EXECUTE_PERMISSION_ID());
+
+        // Alice can create proposals on the plugin
+        dao.grant(address(optimisticPlugin), alice, optimisticPlugin.PROPOSER_PERMISSION_ID());
+
         vm.label(address(dao), "dao");
         vm.label(address(optimisticPlugin), "optimisticPlugin");
 


### PR DESCRIPTION
Adapting the proposalId format of the optimistic plugin, so that startTime, endTime and counter can be parsed on the L2

Note: This should be merged only after PR #13 is already on `main`