### PR TITLE
Metadata URI hash

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,7 +3,7 @@
   "solidity.packageDefaultDependenciesDirectory": "lib",
   "editor.formatOnSave": true,
   "[solidity]": {
-    "editor.defaultFormatter": "NomicFoundation.hardhat-solidity" 
+    "editor.defaultFormatter": "NomicFoundation.hardhat-solidity"
   },
   "solidity.formatter": "forge",
   "solidity.compileUsingRemoteVersion": "v0.8.17"

--- a/DEPLOYMENTS.md
+++ b/DEPLOYMENTS.md
@@ -2,6 +2,32 @@
 
 ## Mainnet
 
+## Holesly
+
+On July 1st 2024:
+
+```
+  Chain ID: 17000
+  
+  Deploying from: 0x424797Ed6d902E17b9180BFcEF452658e148e0Ab
+  Minting test tokens for the multisig members and the bridge
+  Test voting token: 0xa95BADd91beB92F364905187eCB08B80220d5FA3
+  Factory contract: 0xFbA94606d10e807Bf6542C19a68DfEa815a4eeC3
+  
+  DAO contract: 0xdA69Bd97278c409574AdC39295465A848C82CD16
+  
+  - Multisig plugin: 0x2a22Fc29dE8944E62227bf75C89cA2e8CE9BA274
+  - Emergency multisig plugin: 0x7C36a0F03c27880C23f5704296Bc18Bfc33A7f59
+  - Optimistic token voting plugin: 0x40CD85d43B883C83290ed5D18400C640176A9679
+  
+  - Multisig plugin repository: 0x307d009483C1b8Ef3C91F6ae748385Bf0936C59e
+  - Emergency multisig plugin repository: 0x8181da2e9b1a428a4cF60fF6CEFc0098c1298aaA
+  - Optimistic token voting plugin repository: 0x0847F2531e070353297fc3D7fFDB4656C1664c6d
+  
+  Public key registry 0x7A9577A02608446022F52984435ce1ca632BA629
+  Delegation wall 0xE917426E10a54FbF22FDAF32A4151c90550e1cA5
+```
+
 ## Sepolia
 
 On June 13th 2024:

--- a/DEPLOYMENTS.md
+++ b/DEPLOYMENTS.md
@@ -4,26 +4,25 @@
 
 ## Sepolia
 
-On June 6th 2024:
+On June 13th 2024:
 
 ```
 Chain ID: 11155111
 
 Deploying from: 0x424797Ed6d902E17b9180BFcEF452658e148e0Ab
-Test voting token: 0xf7A8F99a1d0AFB3C95f80770223b00e062C6Ec19
-Factory contract: 0x8c99CDb5567206660CA9b77C3B26C13F6C674952
+Test voting token: 0x7Ae1BbFfF99316922cebC74C9465d8E3Cdfc65e3
+Factory contract: 0x8793E7847d4a522aE3b76b2F05AD48C390b079A6
 
-DAO contract: 0x6C477915CC803518723d4Bdd5B2170cf38A57203
+DAO contract: 0x464E808De86C90Ea0423854cABE887b6AEF85c1E
 
-- Multisig plugin: 0x0fC611670228A61824c317926f30e8a2615aa1A3
-- Emergency multisig plugin: 0x619d6661eA06b917e26694f23c5Bb32fa0456773
-- Optimistic token voting plugin: 0xC9304930f6a4fB2DAe74A17032426Aa1E817897A
+- Multisig plugin: 0x07d0ac4ef82cA8E799BAB1f07f5e4f1De933E88C
+- Emergency multisig plugin: 0x143209C5fc8004c4B41cA7Bd27666d884B35c809
+- Optimistic token voting plugin: 0x73aA4dBD85eca05542013dcd893CC9DD0c681184
 
-- Multisig plugin repository: 0x841E3dA30697C8FC7224a43952041001545a2443
-- Emergency multisig plugin repository: 0x6E8578B1519a04BA9262CB633B06624f636D4795
-- Optimistic token voting plugin repository: 0x58CA6f90edB98f9213353f456c685ABF253edAA7
+- Multisig plugin repository: 0xA3E9182048AE97ABd2AF3045d7690Ea87B44beAF
+- Emergency multisig plugin repository: 0x1cF2c1A6075B532df0E9CEA2734AF526Ff058B19
+- Optimistic token voting plugin repository: 0x44Bf21d7d7d052b67A98C924617583f8EBC8a5bC
 
-Public key registry 0xadAb459A189AAaa17D4807805e6Fab55d3fb5C44
-Delegation wall 0x0cE7f031BA69abFB404fE148dD09F597db8AB3a0
+Public key registry 0xD4615654030982779AC1DD0ff3e69FCD8f8b702d
+Delegation wall 0x32ccaee7288e43128C99B5505e6B9cF395ED8b64
 ```
-

--- a/DEPLOYMENTS.md
+++ b/DEPLOYMENTS.md
@@ -1,0 +1,11 @@
+# Deployment list
+
+## Mainnet
+
+## Sepolia
+
+On June 6th 2024:
+
+```
+```
+

--- a/DEPLOYMENTS.md
+++ b/DEPLOYMENTS.md
@@ -7,5 +7,23 @@
 On June 6th 2024:
 
 ```
+Chain ID: 11155111
+
+Deploying from: 0x424797Ed6d902E17b9180BFcEF452658e148e0Ab
+Test voting token: 0xf7A8F99a1d0AFB3C95f80770223b00e062C6Ec19
+Factory contract: 0x8c99CDb5567206660CA9b77C3B26C13F6C674952
+
+DAO contract: 0x6C477915CC803518723d4Bdd5B2170cf38A57203
+
+- Multisig plugin: 0x0fC611670228A61824c317926f30e8a2615aa1A3
+- Emergency multisig plugin: 0x619d6661eA06b917e26694f23c5Bb32fa0456773
+- Optimistic token voting plugin: 0xC9304930f6a4fB2DAe74A17032426Aa1E817897A
+
+- Multisig plugin repository: 0x841E3dA30697C8FC7224a43952041001545a2443
+- Emergency multisig plugin repository: 0x6E8578B1519a04BA9262CB633B06624f636D4795
+- Optimistic token voting plugin repository: 0x58CA6f90edB98f9213353f456c685ABF253edAA7
+
+Public key registry 0xadAb459A189AAaa17D4807805e6Fab55d3fb5C44
+Delegation wall 0x0cE7f031BA69abFB404fE148dD09F597db8AB3a0
 ```
 

--- a/README.md
+++ b/README.md
@@ -177,8 +177,8 @@ $ forge test
 
 1. Edit `script/multisig-members.json` with the list of addresses to set as signers
 2. Run `forge build`
-3. Copy `.env.example` into `.env`
-4. Define the deployment settings within `.env`
+3. Copy `.env.example` into `.env` and define the settings
+4. Run `source .env` to load them
 5. Set the RPC URL and run the deployment script
 
 ```shell

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The Security Council has a standard multisig plugin and an emergency variant. Th
 
 [Learn more about Aragon OSx](#protocol-overview).
 
-See [Deploying the DAO](#deploying-the-dao) below.
+See [Deploying the DAO](#deploying-the-dao) below and check out the [latest deployments](./DEPLOYMENTS.md).
 
 ## Optimistic Token Voting plugin
 

--- a/foundry.toml
+++ b/foundry.toml
@@ -9,9 +9,11 @@ optimizer-runs = 10_000_000
 solc = "0.8.17"
 
 [rpc_endpoints]
+holesky = "https://eth-holesky.g.alchemy.com/v2/${ALCHEMY_API_KEY}"
 sepolia = "https://eth-sepolia.g.alchemy.com/v2/${ALCHEMY_API_KEY}"
 mainnet = "https://eth-mainnet.g.alchemy.com/v2/${ALCHEMY_API_KEY}"
 
 [etherscan]
+holesly = { key = "${ETHERSCAN_API_KEY}" }
 sepolia = { key = "${ETHERSCAN_API_KEY}" }
 mainnet = { key = "${ETHERSCAN_API_KEY}" }

--- a/script/Deploy.s.sol
+++ b/script/Deploy.s.sol
@@ -36,8 +36,8 @@ contract Deploy is Script {
         );
 
         console.log("Chain ID:", block.chainid);
-        console.log("Deploying from:", vm.addr(vm.envUint("DEPLOYMENT_PRIVATE_KEY")));
         console.log("");
+        console.log("Deploying from:", vm.addr(vm.envUint("DEPLOYMENT_PRIVATE_KEY")));
 
         TaikoDaoFactory.DeploymentSettings memory settings;
         if (block.chainid == 1) {
@@ -55,6 +55,7 @@ contract Deploy is Script {
 
         // Print summary
         console.log("Factory contract:", address(factory));
+        console.log("");
         console.log("DAO contract:", address(daoDeployment.dao));
         console.log("");
 
@@ -110,7 +111,6 @@ contract Deploy is Script {
         address votingToken = createTestToken(multisigMembers, taikoBridgeAddress);
 
         console.log("Test voting token:", votingToken);
-        console.log("");
 
         settings = TaikoDaoFactory.DeploymentSettings({
             // Taiko contract settings

--- a/src/DelegationWall.sol
+++ b/src/DelegationWall.sol
@@ -22,6 +22,7 @@ contract DelegationWall {
     /// @notice Raised when a delegate registers with an empty contentUrl
     error EmptyContent();
 
+    /// @notice Registers the given data as a new delegation candidate
     function register(bytes memory _contentUrl) public {
         if (_contentUrl.length == 0) revert EmptyContent();
 

--- a/src/DelegationWall.sol
+++ b/src/DelegationWall.sol
@@ -12,6 +12,7 @@ contract DelegationWall {
 
     /// @dev Stores the data registered by the delegate candidates
     mapping(address => Candidate) public candidates;
+
     /// @dev Keeps track of the addresses that have been already registered, used to enumerate.
     address[] public candidateAddresses;
 
@@ -33,6 +34,13 @@ contract DelegationWall {
         emit CandidateRegistered(msg.sender, _contentUrl);
     }
 
+    /// @notice Returns the list of candidate addresses registered
+    /// @dev Use this function to get all addresses in a single call. You can still call candidateAddresses[idx] to resolve them one by one.
+    function getCandidateAddresses() public view returns (address[] memory) {
+        return candidateAddresses;
+    }
+
+    /// @notice Returns the number of candidate entries available
     function candidateCount() public view returns (uint256) {
         return candidateAddresses.length;
     }

--- a/src/EmergencyMultisig.sol
+++ b/src/EmergencyMultisig.sol
@@ -28,8 +28,8 @@ contract EmergencyMultisig is IEmergencyMultisig, IMembership, PluginUUPSUpgrade
     /// @param parameters The proposal-specific approve settings at the time of the proposal creation.
     /// @param approvers The approves casted by the approvers.
     /// @param encryptedPayloadURI The IPFS URI where a JSON with the encrypted payload is pinned
-    /// @param destinationActionsHash The hash of the serialized list of final actions to be eventually executed
     /// @param publicMetadataUriHash The hash of the metadata IPFS URI to be created on the optimistic proposal
+    /// @param destinationActionsHash The hash of the serialized list of final actions to be eventually executed
     /// @param destinationPlugin The address of the plugin where the proposal will be created if it passes.
     struct Proposal {
         bool executed;
@@ -293,14 +293,14 @@ contract EmergencyMultisig is IEmergencyMultisig, IMembership, PluginUUPSUpgrade
             revert ProposalExecutionForbidden(_proposalId);
         }
 
-        if (proposals[_proposalId].destinationActionsHash != hashActions(_actions)) {
-            // This check is intentionally not part of canExecute() in order to prevent
-            // the private actions from leaving the app before being executed
-            revert InvalidActions(_proposalId);
-        } else if (proposals[_proposalId].publicMetadataUriHash != keccak256(_metadataUri)) {
+        if (proposals[_proposalId].publicMetadataUriHash != keccak256(_metadataUri)) {
             // This check is intentionally not part of canExecute() in order to prevent
             // the the metadata from leaving the app before being executed
             revert InvalidMetadataUri(_proposalId);
+        } else if (proposals[_proposalId].destinationActionsHash != hashActions(_actions)) {
+            // This check is intentionally not part of canExecute() in order to prevent
+            // the private actions from leaving the app before being executed
+            revert InvalidActions(_proposalId);
         }
 
         _execute(_proposalId, _metadataUri, _actions);

--- a/src/OptimisticTokenVotingPlugin.sol
+++ b/src/OptimisticTokenVotingPlugin.sol
@@ -99,6 +99,9 @@ contract OptimisticTokenVotingPlugin is
     /// @notice A mapping between proposal IDs and proposal information.
     mapping(uint256 => Proposal) internal proposals;
 
+    /// @notice A mapping to enumerate proposal ID's by index
+    mapping(uint256 => uint256) public proposalIds;
+
     /// @notice Emitted when the vetoing settings are updated.
     /// @param minVetoRatio The minimum veto ratio needed to defeat the proposal, as a fraction of 1_000_000.
     /// @param minDuration The minimum duration of the proposal vote in seconds.
@@ -358,6 +361,8 @@ contract OptimisticTokenVotingPlugin is
             _actions: _actions,
             _allowFailureMap: _allowFailureMap
         });
+        // Index the ID to make it enumerable. Proposal ID's contain timestamps and cannot be iterated
+        proposalIds[proposalCount() - 1] = proposalId;
 
         // Store proposal related information
         Proposal storage proposal_ = proposals[proposalId];
@@ -549,5 +554,5 @@ contract OptimisticTokenVotingPlugin is
     }
 
     /// @notice This empty reserved space is put in place to allow future versions to add new variables without shifting down storage in the inheritance chain (see [OpenZeppelin's guide about storage gaps](https://docs.openzeppelin.com/contracts/4.x/upgradeable#storage_gaps)).
-    uint256[45] private __gap;
+    uint256[44] private __gap;
 }

--- a/src/PublicKeyRegistry.sol
+++ b/src/PublicKeyRegistry.sol
@@ -6,7 +6,10 @@ pragma solidity ^0.8.17;
 /// @author Aragon Association - 2024
 /// @notice A smart contract where any wallet can register its own libsodium public key for encryption purposes
 contract PublicKeyRegistry {
-    mapping(address => bytes32) internal publicKeys;
+    mapping(address => bytes32) public publicKeys;
+
+    /// @dev Allows to enumerate the wallets that have a public key registered
+    address[] public registeredWallets;
 
     /// @notice Emitted when a public key is registered
     event PublicKeyRegistered(address wallet, bytes32 publicKey);
@@ -19,9 +22,17 @@ contract PublicKeyRegistry {
 
         publicKeys[msg.sender] = _publicKey;
         emit PublicKeyRegistered(msg.sender, _publicKey);
+        registeredWallets.push(msg.sender);
     }
 
-    function getPublicKey(address _wallet) public view returns (bytes32) {
-        return publicKeys[_wallet];
+    /// @notice Returns the list of wallets that have registered a public key
+    /// @dev Use this function to get all addresses in a single call. You can still call registeredWallets[idx] to resolve them one by one.
+    function getRegisteredWallets() public view returns (address[] memory) {
+        return registeredWallets;
+    }
+
+    /// @notice Returns the number of publicKey entries available
+    function registeredWalletCount() public view returns (uint256) {
+        return registeredWallets.length;
     }
 }

--- a/src/interfaces/IEmergencyMultisig.sol
+++ b/src/interfaces/IEmergencyMultisig.sol
@@ -34,6 +34,7 @@ interface IEmergencyMultisig {
 
     /// @notice Executes a proposal.
     /// @param _proposalId The ID of the proposal to be executed.
+    /// @param _metadataUri An IPFS URI pointing to the public content URI.
     /// @param _actions the list of actions to execute.
-    function execute(uint256 _proposalId, IDAO.Action[] calldata _actions) external;
+    function execute(uint256 _proposalId, bytes memory _metadataUri, IDAO.Action[] calldata _actions) external;
 }

--- a/src/setup/EmergencyMultisigPluginSetup.sol
+++ b/src/setup/EmergencyMultisigPluginSetup.sol
@@ -25,8 +25,8 @@ contract EmergencyMultisigPluginSetup is PluginSetup {
         external
         returns (address plugin, PreparedSetupData memory preparedSetupData)
     {
-        // Decode `_data` to extract the params needed for deploying and initializing `EmergencyMultisig` plugin.
-        (EmergencyMultisig.MultisigSettings memory multisigSettings) = decodeInstallationParams(_data);
+        // Decode `_data` to extract the parameters needed for deploying and initializing `EmergencyMultisig` plugin.
+        (EmergencyMultisig.MultisigSettings memory multisigSettings) = decodeInstallationParameters(_data);
 
         // Prepare and Deploy the plugin proxy.
         plugin = createERC1967Proxy(
@@ -34,7 +34,7 @@ contract EmergencyMultisigPluginSetup is PluginSetup {
         );
 
         // Prepare permissions
-        PermissionLib.MultiTargetPermission[] memory permissions = new PermissionLib.MultiTargetPermission[](3);
+        PermissionLib.MultiTargetPermission[] memory permissions = new PermissionLib.MultiTargetPermission[](2);
 
         // Set permissions to be granted.
         // Grant the list of permissions of the plugin to the DAO.
@@ -107,7 +107,7 @@ contract EmergencyMultisigPluginSetup is PluginSetup {
     }
 
     /// @notice Decodes the given byte array into the original installation parameters
-    function decodeInstallationParams(bytes memory _data)
+    function decodeInstallationParameters(bytes memory _data)
         public
         pure
         returns (EmergencyMultisig.MultisigSettings memory _multisigSettings)

--- a/src/setup/MultisigPluginSetup.sol
+++ b/src/setup/MultisigPluginSetup.sol
@@ -21,31 +21,21 @@ contract MultisigPluginSetup is PluginSetup {
     }
 
     /// @inheritdoc IPluginSetup
-    function prepareInstallation(
-        address _dao,
-        bytes calldata _data
-    )
+    function prepareInstallation(address _dao, bytes calldata _data)
         external
         returns (address plugin, PreparedSetupData memory preparedSetupData)
     {
-        // Decode `_data` to extract the params needed for deploying and initializing `Multisig` plugin.
-        (
-            address[] memory members,
-            Multisig.MultisigSettings memory multisigSettings
-        ) = decodeInstallationParams(_data);
+        // Decode `_data` to extract the parameters needed for deploying and initializing `Multisig` plugin.
+        (address[] memory members, Multisig.MultisigSettings memory multisigSettings) =
+            decodeInstallationParameters(_data);
 
         // Prepare and Deploy the plugin proxy.
         plugin = createERC1967Proxy(
-            address(multisigBase),
-            abi.encodeCall(
-                Multisig.initialize,
-                (IDAO(_dao), members, multisigSettings)
-            )
+            address(multisigBase), abi.encodeCall(Multisig.initialize, (IDAO(_dao), members, multisigSettings))
         );
 
         // Prepare permissions
-        PermissionLib.MultiTargetPermission[]
-            memory permissions = new PermissionLib.MultiTargetPermission[](3);
+        PermissionLib.MultiTargetPermission[] memory permissions = new PermissionLib.MultiTargetPermission[](2);
 
         // Set permissions to be granted.
         // Grant the list of permissions of the plugin to the DAO.
@@ -69,25 +59,15 @@ contract MultisigPluginSetup is PluginSetup {
     }
 
     /// @inheritdoc IPluginSetup
-    function prepareUpdate(
-        address _dao,
-        uint16 _currentBuild,
-        SetupPayload calldata _payload
-    )
+    function prepareUpdate(address _dao, uint16 _currentBuild, SetupPayload calldata _payload)
         external
         pure
         override
-        returns (
-            bytes memory initData,
-            PreparedSetupData memory preparedSetupData
-        )
+        returns (bytes memory initData, PreparedSetupData memory preparedSetupData)
     {}
 
     /// @inheritdoc IPluginSetup
-    function prepareUninstallation(
-        address _dao,
-        SetupPayload calldata _payload
-    )
+    function prepareUninstallation(address _dao, SetupPayload calldata _payload)
         external
         view
         returns (PermissionLib.MultiTargetPermission[] memory permissions)
@@ -119,27 +99,20 @@ contract MultisigPluginSetup is PluginSetup {
     }
 
     /// @notice Encodes the given installation parameters into a byte array
-    function encodeInstallationParameters(
-        address[] memory _members,
-        Multisig.MultisigSettings memory _multisigSettings
-    ) external pure returns (bytes memory) {
+    function encodeInstallationParameters(address[] memory _members, Multisig.MultisigSettings memory _multisigSettings)
+        external
+        pure
+        returns (bytes memory)
+    {
         return abi.encode(_members, _multisigSettings);
     }
 
     /// @notice Decodes the given byte array into the original installation parameters
-    function decodeInstallationParams(
-        bytes memory _data
-    )
+    function decodeInstallationParameters(bytes memory _data)
         public
         pure
-        returns (
-            address[] memory _members,
-            Multisig.MultisigSettings memory _multisigSettings
-        )
+        returns (address[] memory _members, Multisig.MultisigSettings memory _multisigSettings)
     {
-        (_members, _multisigSettings) = abi.decode(
-            _data,
-            (address[], Multisig.MultisigSettings)
-        );
+        (_members, _multisigSettings) = abi.decode(_data, (address[], Multisig.MultisigSettings));
     }
 }

--- a/test/DelegationWall.t.sol
+++ b/test/DelegationWall.t.sol
@@ -216,6 +216,24 @@ contract EmergencyMultisigTest is AragonTest {
         assertEq(wall.candidateAddresses(3), david, "Incorrect candidate address");
     }
 
+    function test_ShouldLoadTheRegisteredAddresses() public {
+        vm.startPrank(alice);
+        wall.register("https://");
+        vm.startPrank(bob);
+        wall.register("https://taiko.xyz");
+        vm.startPrank(carol);
+        wall.register("https://x.com/carol");
+        vm.startPrank(david);
+        wall.register("https://defeat-goliath.org");
+
+        address[] memory candidates = wall.getCandidateAddresses();
+        assertEq(candidates.length, 4);
+        assertEq(candidates[0], alice);
+        assertEq(candidates[1], bob);
+        assertEq(candidates[2], carol);
+        assertEq(candidates[3], david);
+    }
+
     function test_ShouldEmitAnEventWhenRegistering() public {
         // Alice
         vm.startPrank(alice);

--- a/test/EmergencyMultisigPluginSetup.t.sol
+++ b/test/EmergencyMultisigPluginSetup.t.sol
@@ -1,0 +1,179 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.17;
+
+import {Test} from "forge-std/Test.sol";
+import {EmergencyMultisig} from "../src/EmergencyMultisig.sol";
+import {Multisig} from "../src/Multisig.sol";
+import {EmergencyMultisigPluginSetup} from "../src/setup/EmergencyMultisigPluginSetup.sol";
+import {GovernanceERC20} from "@aragon/osx/token/ERC20/governance/GovernanceERC20.sol";
+import {GovernanceWrappedERC20} from "@aragon/osx/token/ERC20/governance/GovernanceWrappedERC20.sol";
+import {IERC20Upgradeable} from "@openzeppelin/contracts-upgradeable/token/ERC20/IERC20Upgradeable.sol";
+import {IDAO} from "@aragon/osx/core/dao/IDAO.sol";
+import {RATIO_BASE} from "@aragon/osx/plugins/utils/Ratio.sol";
+import {DAO} from "@aragon/osx/core/dao/DAO.sol";
+import {IPluginSetup} from "@aragon/osx/framework/plugin/setup/PluginSetup.sol";
+import {PermissionLib} from "@aragon/osx/core/permission/PermissionLib.sol";
+import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
+import {ERC20Mock} from "./mocks/ERC20Mock.sol";
+import {TaikoL1} from "../src/adapted-dependencies/TaikoL1.sol";
+
+contract EmergencyMultisigPluginSetupTest is Test {
+    EmergencyMultisigPluginSetup public pluginSetup;
+    GovernanceERC20 governanceERC20Base;
+    GovernanceWrappedERC20 governanceWrappedERC20Base;
+    address immutable daoBase = address(new DAO());
+    address immutable stdMultisigBase = address(new Multisig());
+    DAO dao;
+
+    // Recycled installation parameters
+    EmergencyMultisig.MultisigSettings eMultisigSettings;
+    address[] stdMembers;
+    Multisig stdMultisig;
+
+    address alice = address(0xa11ce);
+    address bob = address(0xb0b);
+    address carol = address(0xc4601);
+    address dave = address(0xd473);
+
+    error Unimplemented();
+
+    function setUp() public {
+        pluginSetup = new EmergencyMultisigPluginSetup();
+
+        // Address list source (std multisig)
+        stdMembers = new address[](4);
+        stdMembers[0] = alice;
+        stdMembers[1] = bob;
+        stdMembers[2] = carol;
+        stdMembers[3] = dave;
+        Multisig.MultisigSettings memory stdSettings =
+            Multisig.MultisigSettings({onlyListed: true, minApprovals: 3, destinationProposalDuration: 10 days});
+        stdMultisig = Multisig(
+            createProxyAndCall(
+                stdMultisigBase, abi.encodeCall(Multisig.initialize, (IDAO(dao), stdMembers, stdSettings))
+            )
+        );
+
+        // Default params
+        eMultisigSettings =
+            EmergencyMultisig.MultisigSettings({onlyListed: true, minApprovals: 3, addresslistSource: stdMultisig});
+    }
+
+    function test_ShouldEncodeInstallationParameters_1() public view {
+        // 1
+        bytes memory output = pluginSetup.encodeInstallationParameters(eMultisigSettings);
+
+        bytes memory expected =
+            hex"000000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000000030000000000000000000000005991a2df15a8f6a256d3ec51e99254cd3fb576a9";
+        assertEq(output, expected, "Incorrect encoded bytes");
+    }
+
+    function test_ShouldEncodeInstallationParameters_2() public {
+        // 2
+        stdMembers = new address[](2);
+        stdMembers[0] = alice;
+        stdMembers[1] = bob;
+        Multisig.MultisigSettings memory stdSettings =
+            Multisig.MultisigSettings({onlyListed: true, minApprovals: 1, destinationProposalDuration: 10 days});
+        stdMultisig = Multisig(
+            createProxyAndCall(
+                stdMultisigBase, abi.encodeCall(Multisig.initialize, (IDAO(dao), stdMembers, stdSettings))
+            )
+        );
+
+        eMultisigSettings =
+            EmergencyMultisig.MultisigSettings({onlyListed: true, minApprovals: 1, addresslistSource: stdMultisig});
+
+        bytes memory output = pluginSetup.encodeInstallationParameters(eMultisigSettings);
+        bytes memory expected =
+            hex"00000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000001000000000000000000000000c7183455a4c133ae270771860664b6b7ec320bb1";
+        assertEq(output, expected, "Incorrect encoded bytes");
+    }
+
+    function test_ShouldDecodeInstallationParameters_1() public view {
+        // 1
+        bytes memory installationParams = pluginSetup.encodeInstallationParameters(eMultisigSettings);
+
+        // Decode
+        (EmergencyMultisig.MultisigSettings memory outSettings) =
+            pluginSetup.decodeInstallationParameters(installationParams);
+
+        assertEq(outSettings.onlyListed, true, "Should be true");
+        assertEq(outSettings.minApprovals, 3, "Should be 3");
+        assertEq(
+            address(outSettings.addresslistSource),
+            address(eMultisigSettings.addresslistSource),
+            "Incorrect address list source"
+        );
+    }
+
+    function test_ShouldDecodeInstallationParameters_2() public {
+        // 2
+
+        stdMembers = new address[](2);
+        stdMembers[0] = alice;
+        stdMembers[1] = bob;
+        Multisig.MultisigSettings memory stdSettings =
+            Multisig.MultisigSettings({onlyListed: true, minApprovals: 1, destinationProposalDuration: 10 days});
+        stdMultisig = Multisig(
+            createProxyAndCall(
+                stdMultisigBase, abi.encodeCall(Multisig.initialize, (IDAO(dao), stdMembers, stdSettings))
+            )
+        );
+        eMultisigSettings =
+            EmergencyMultisig.MultisigSettings({onlyListed: false, minApprovals: 1, addresslistSource: stdMultisig});
+
+        bytes memory installationParams = pluginSetup.encodeInstallationParameters(eMultisigSettings);
+
+        // Decode
+        (EmergencyMultisig.MultisigSettings memory outSettings) =
+            pluginSetup.decodeInstallationParameters(installationParams);
+
+        assertEq(outSettings.onlyListed, false, "Should be false");
+        assertEq(outSettings.minApprovals, 1, "Should be 1");
+        assertEq(address(outSettings.addresslistSource), address(stdMultisig), "Incorrect address list source");
+    }
+
+    function test_PrepareInstallationReturnsTheProperPermissions() public {
+        bytes memory installationParams = pluginSetup.encodeInstallationParameters(eMultisigSettings);
+
+        (address _plugin, IPluginSetup.PreparedSetupData memory _preparedSetupData) =
+            pluginSetup.prepareInstallation(address(dao), installationParams);
+
+        assertEq(_plugin != address(0), true, "Plugin address should not be zero");
+        assertEq(_preparedSetupData.helpers.length, 0, "Zero helpers expected");
+        assertEq(
+            _preparedSetupData.permissions.length,
+            2, // permissions
+            "Incorrect permission length"
+        );
+        // 1
+        assertEq(
+            uint256(_preparedSetupData.permissions[0].operation),
+            uint256(PermissionLib.Operation.Grant),
+            "Incorrect operation"
+        );
+        assertEq(_preparedSetupData.permissions[0].where, _plugin, "Incorrect where");
+        assertEq(_preparedSetupData.permissions[0].who, address(dao), "Incorrect who");
+        assertEq(_preparedSetupData.permissions[0].condition, address(0), "Incorrect condition");
+        assertEq(
+            _preparedSetupData.permissions[0].permissionId,
+            keccak256("UPDATE_MULTISIG_SETTINGS_PERMISSION"),
+            "Incorrect permission id"
+        );
+        // 2
+        assertEq(_preparedSetupData.permissions[1].where, _plugin, "Incorrect where");
+        assertEq(_preparedSetupData.permissions[1].who, address(dao), "Incorrect who");
+        assertEq(_preparedSetupData.permissions[1].condition, address(0), "Incorrect condition");
+        assertEq(
+            _preparedSetupData.permissions[1].permissionId,
+            keccak256("UPGRADE_PLUGIN_PERMISSION"),
+            "Incorrect permission id"
+        );
+    }
+
+    // HELPERS
+    function createProxyAndCall(address _logic, bytes memory _data) private returns (address) {
+        return address(new ERC1967Proxy(_logic, _data));
+    }
+}

--- a/test/MultisigPluginSetup.t.sol
+++ b/test/MultisigPluginSetup.t.sol
@@ -1,0 +1,160 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.17;
+
+import {Test} from "forge-std/Test.sol";
+import {Multisig} from "../src/Multisig.sol";
+import {MultisigPluginSetup} from "../src/setup/MultisigPluginSetup.sol";
+import {GovernanceERC20} from "@aragon/osx/token/ERC20/governance/GovernanceERC20.sol";
+import {GovernanceWrappedERC20} from "@aragon/osx/token/ERC20/governance/GovernanceWrappedERC20.sol";
+import {IERC20Upgradeable} from "@openzeppelin/contracts-upgradeable/token/ERC20/IERC20Upgradeable.sol";
+import {IDAO} from "@aragon/osx/core/dao/IDAO.sol";
+import {RATIO_BASE} from "@aragon/osx/plugins/utils/Ratio.sol";
+import {DAO} from "@aragon/osx/core/dao/DAO.sol";
+import {IPluginSetup} from "@aragon/osx/framework/plugin/setup/PluginSetup.sol";
+import {PermissionLib} from "@aragon/osx/core/permission/PermissionLib.sol";
+import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
+import {ERC20Mock} from "./mocks/ERC20Mock.sol";
+import {TaikoL1} from "../src/adapted-dependencies/TaikoL1.sol";
+
+contract MultisigPluginSetupTest is Test {
+    MultisigPluginSetup public pluginSetup;
+    GovernanceERC20 governanceERC20Base;
+    GovernanceWrappedERC20 governanceWrappedERC20Base;
+    address immutable daoBase = address(new DAO());
+    DAO dao;
+
+    // Recycled installation parameters
+    Multisig.MultisigSettings multisigSettings;
+    address[] members;
+
+    address alice = address(0xa11ce);
+    address bob = address(0xb0b);
+    address carol = address(0xc4601);
+    address dave = address(0xd473);
+
+    error Unimplemented();
+
+    function setUp() public {
+        pluginSetup = new MultisigPluginSetup();
+
+        // Default params
+        multisigSettings =
+            Multisig.MultisigSettings({onlyListed: true, minApprovals: 3, destinationProposalDuration: 10 days});
+
+        members = new address[](4);
+        members[0] = alice;
+        members[1] = bob;
+        members[2] = carol;
+        members[3] = dave;
+    }
+
+    function test_ShouldEncodeInstallationParameters_1() public view {
+        // 1
+        bytes memory output = pluginSetup.encodeInstallationParameters(members, multisigSettings);
+
+        bytes memory expected =
+            hex"00000000000000000000000000000000000000000000000000000000000000800000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000000300000000000000000000000000000000000000000000000000000000000d2f00000000000000000000000000000000000000000000000000000000000000000400000000000000000000000000000000000000000000000000000000000a11ce0000000000000000000000000000000000000000000000000000000000000b0b00000000000000000000000000000000000000000000000000000000000c4601000000000000000000000000000000000000000000000000000000000000d473";
+        assertEq(output, expected, "Incorrect encoded bytes");
+    }
+
+    function test_ShouldEncodeInstallationParameters_2() public {
+        // 2
+        multisigSettings =
+            Multisig.MultisigSettings({onlyListed: true, minApprovals: 1, destinationProposalDuration: 5 days});
+
+        members = new address[](2);
+        members[0] = alice;
+        members[1] = bob;
+
+        bytes memory output = pluginSetup.encodeInstallationParameters(members, multisigSettings);
+        bytes memory expected =
+            hex"0000000000000000000000000000000000000000000000000000000000000080000000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000069780000000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000a11ce0000000000000000000000000000000000000000000000000000000000000b0b";
+        assertEq(output, expected, "Incorrect encoded bytes");
+    }
+
+    function test_ShouldDecodeInstallationParameters_1() public view {
+        // 1
+        bytes memory installationParams = pluginSetup.encodeInstallationParameters(members, multisigSettings);
+
+        // Decode
+        (address[] memory outMembers, Multisig.MultisigSettings memory outSettings) =
+            pluginSetup.decodeInstallationParameters(installationParams);
+
+        assertEq(outMembers.length, 4, "Incorrect length");
+        assertEq(outMembers[0], alice, "Incorrect member");
+        assertEq(outMembers[1], bob, "Incorrect member");
+        assertEq(outMembers[2], carol, "Incorrect member");
+        assertEq(outMembers[3], dave, "Incorrect member");
+
+        assertEq(outSettings.onlyListed, true, "Should be true");
+        assertEq(outSettings.minApprovals, 3, "Should be 3");
+        assertEq(outSettings.destinationProposalDuration, 10 days, "Should be 10 days");
+    }
+
+    function test_ShouldDecodeInstallationParameters_2() public {
+        // 2
+        multisigSettings =
+            Multisig.MultisigSettings({onlyListed: false, minApprovals: 1, destinationProposalDuration: 5 days});
+
+        members = new address[](2);
+        members[0] = alice;
+        members[1] = bob;
+
+        bytes memory installationParams = pluginSetup.encodeInstallationParameters(members, multisigSettings);
+
+        // Decode
+        (address[] memory outMembers, Multisig.MultisigSettings memory outSettings) =
+            pluginSetup.decodeInstallationParameters(installationParams);
+
+        assertEq(outMembers.length, 2, "Incorrect length");
+        assertEq(outMembers[0], alice, "Incorrect member");
+        assertEq(outMembers[1], bob, "Incorrect member");
+
+        assertEq(outSettings.onlyListed, false, "Should be false");
+        assertEq(outSettings.minApprovals, 1, "Should be 1");
+        assertEq(outSettings.destinationProposalDuration, 5 days, "Should be 5 days");
+    }
+
+    function test_PrepareInstallationReturnsTheProperPermissions() public {
+        bytes memory installationParams = pluginSetup.encodeInstallationParameters(members, multisigSettings);
+
+        (address _plugin, IPluginSetup.PreparedSetupData memory _preparedSetupData) =
+            pluginSetup.prepareInstallation(address(dao), installationParams);
+
+        assertEq(_plugin != address(0), true, "Plugin address should not be zero");
+        assertEq(_preparedSetupData.helpers.length, 0, "Zero helpers expected");
+        assertEq(
+            _preparedSetupData.permissions.length,
+            2, // permissions
+            "Incorrect permission length"
+        );
+        // 1
+        assertEq(
+            uint256(_preparedSetupData.permissions[0].operation),
+            uint256(PermissionLib.Operation.Grant),
+            "Incorrect operation"
+        );
+        assertEq(_preparedSetupData.permissions[0].where, _plugin, "Incorrect where");
+        assertEq(_preparedSetupData.permissions[0].who, address(dao), "Incorrect who");
+        assertEq(_preparedSetupData.permissions[0].condition, address(0), "Incorrect condition");
+        assertEq(
+            _preparedSetupData.permissions[0].permissionId,
+            keccak256("UPDATE_MULTISIG_SETTINGS_PERMISSION"),
+            "Incorrect permission id"
+        );
+        // 2
+        assertEq(_preparedSetupData.permissions[1].where, _plugin, "Incorrect where");
+        assertEq(_preparedSetupData.permissions[1].who, address(dao), "Incorrect who");
+        assertEq(_preparedSetupData.permissions[1].condition, address(0), "Incorrect condition");
+        assertEq(
+            _preparedSetupData.permissions[1].permissionId,
+            keccak256("UPGRADE_PLUGIN_PERMISSION"),
+            "Incorrect permission id"
+        );
+    }
+
+    // HELPERS
+    function createProxyAndCall(address _logic, bytes memory _data) private returns (address) {
+        return address(new ERC1967Proxy(_logic, _data));
+    }
+}

--- a/test/OptimisticTokenVotingPlugin.t.sol
+++ b/test/OptimisticTokenVotingPlugin.t.sol
@@ -862,6 +862,45 @@ contract OptimisticTokenVotingPluginTest is AragonTest {
         assertEq(proposalId, expectedPid, "Should have created proposal 2");
     }
 
+    function test_CreateProposalIncrementsTheProposalCounter() public {
+        IDAO.Action[] memory actions = new IDAO.Action[](0);
+        assertEq(optimisticPlugin.proposalCount(), 0);
+        optimisticPlugin.createProposal("", actions, 0, 10 days);
+        assertEq(optimisticPlugin.proposalCount(), 1);
+        optimisticPlugin.createProposal("ipfs://", actions, 0, 10 days);
+        assertEq(optimisticPlugin.proposalCount(), 2);
+        optimisticPlugin.createProposal("", actions, 255, 15 days);
+        assertEq(optimisticPlugin.proposalCount(), 3);
+        optimisticPlugin.createProposal("", actions, 127, 20 days);
+        assertEq(optimisticPlugin.proposalCount(), 4);
+        optimisticPlugin.createProposal("ipfs://meta", actions, 0, 10 days);
+        assertEq(optimisticPlugin.proposalCount(), 5);
+        optimisticPlugin.createProposal("", actions, 0, 100 days);
+        assertEq(optimisticPlugin.proposalCount(), 6);
+    }
+
+    function test_CreateProposalIndexesThePid() public {
+        uint256 expectedPid = uint256(block.timestamp) << 128 | uint256(block.timestamp + 10 days) << 64;
+
+        IDAO.Action[] memory actions = new IDAO.Action[](0);
+        // 1
+        assertEq(optimisticPlugin.proposalIds(0), 0);
+        optimisticPlugin.createProposal("", actions, 0, 10 days);
+        assertEq(optimisticPlugin.proposalIds(0), expectedPid);
+
+        // 2
+        expectedPid = uint256(block.timestamp) << 128 | uint256(block.timestamp + 100 days) << 64 | 1;
+        assertEq(optimisticPlugin.proposalIds(1), 0);
+        optimisticPlugin.createProposal("ipfs://meta", actions, 0, 100 days);
+        assertEq(optimisticPlugin.proposalIds(1), expectedPid);
+
+        // 3
+        expectedPid = uint256(block.timestamp) << 128 | uint256(block.timestamp + 50 days) << 64 | 2;
+        assertEq(optimisticPlugin.proposalIds(2), 0);
+        optimisticPlugin.createProposal("", actions, 0, 50 days);
+        assertEq(optimisticPlugin.proposalIds(2), expectedPid);
+    }
+
     function test_CreateProposalEmitsAnEvent() public {
         uint256 expectedPid = uint256(block.timestamp) << 128 | uint256(block.timestamp + 10 days) << 64;
 


### PR DESCRIPTION
This PR should be merged after #21 
- Adding a (public) metadata URI hash for emergency proposals
- Verify that the metadata URI hash is the same when recreating on the optimistic plugin
- Renaming `ProposalCreated()` to `EmergencyProposalCreated()` to avoid collisions on the ABI when using it as an artifact. 
- New tests