### PR TITLE
feat: update to use taiko protocol v1.9.0

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -13,6 +13,3 @@
 [submodule "lib/ens-contracts"]
 	path = lib/ens-contracts
 	url = https://github.com/ensdomains/ens-contracts.git
-[submodule "lib/taiko-mono"]
-	path = lib/taiko-mono
-	url = https://github.com/taikoxyz/taiko-mono

--- a/remappings.txt
+++ b/remappings.txt
@@ -3,4 +3,3 @@
 @aragon/osx/=lib/osx/packages/contracts/src/
 @ensdomains/ens-contracts/=lib/ens-contracts/
 forge-std/=lib/forge-std/src/
-@taikoxyz/taiko-mono=lib/taiko-mono/packages/protocol/contracts/

--- a/src/OptimisticTokenVotingPlugin.sol
+++ b/src/OptimisticTokenVotingPlugin.sol
@@ -14,7 +14,7 @@ import {ProposalUpgradeable} from "@aragon/osx/core/plugin/proposal/ProposalUpgr
 import {PluginUUPSUpgradeable} from "@aragon/osx/core/plugin/PluginUUPSUpgradeable.sol";
 import {RATIO_BASE, _applyRatioCeiled, RatioOutOfBounds} from "@aragon/osx/plugins/utils/Ratio.sol";
 import {IDAO} from "@aragon/osx/core/dao/IDAO.sol";
-import {TaikoL1} from "./adapted-dependencies/TaikoL1.sol";
+import {ITaikoL1} from "./adapted-dependencies/ITaikoL1.sol";
 
 /// @title OptimisticTokenVotingPlugin
 /// @author Aragon Association - 2023-2024
@@ -91,7 +91,7 @@ contract OptimisticTokenVotingPlugin is
     address public taikoBridge;
 
     /// @notice Taiko L1 contract to check the status from.
-    TaikoL1 public taikoL1;
+    ITaikoL1 public taikoL1;
 
     /// @notice The struct storing the governance settings.
     /// @dev Takes 1 storage slot (32+64+64+64)
@@ -168,7 +168,7 @@ contract OptimisticTokenVotingPlugin is
         if (_taikoL1 == address(0)) revert();
 
         votingToken = _token;
-        taikoL1 = TaikoL1(_taikoL1);
+        taikoL1 = ITaikoL1(_taikoL1);
         taikoBridge = _taikoBridge;
 
         _updateOptimisticGovernanceSettings(_governanceSettings);

--- a/src/OptimisticTokenVotingPlugin.sol
+++ b/src/OptimisticTokenVotingPlugin.sol
@@ -220,12 +220,12 @@ contract OptimisticTokenVotingPlugin is
             return false;
         }
 
-        try taikoL1.slotB() returns (TaikoData.SlotB memory _slot) {
+        try taikoL1.getStateVariables() returns (TaikoData.SlotA memory, TaikoData.SlotB memory _slotB) {
             // No L2 blocks yet
-            if (_slot.numBlocks == 0) return false;
+            if (_slotB.numBlocks == 0) return false;
 
             // The last L2 block is too old
-            TaikoData.Block memory _block = taikoL1.getBlock(_slot.numBlocks - 1);
+            TaikoData.BlockV2 memory _block = taikoL1.getBlockV2(_slotB.numBlocks - 1);
             // proposedAt < (block.timestamp - l2InactivityPeriod), written as a sum
             if ((_block.proposedAt + governanceSettings.l2InactivityPeriod) < block.timestamp) return false;
         } catch {

--- a/src/adapted-dependencies/ITaikoL1.sol
+++ b/src/adapted-dependencies/ITaikoL1.sol
@@ -4,10 +4,10 @@ pragma solidity ^0.8.17;
 /// @dev Manual copy of lib/taiko-mono/packages/protocol/contracts/L1/TaikoL1.sol and its dependent structs
 /// from https://github.com/taikoxyz/taiko-mono/tree/protocol-v1.9.0.
 /// This is in order to overcome the conflicting compiler versions between 0.8.17 (OSx) and 0.8.24 (Taiko)
-abstract contract TaikoL1 {
+interface ITaikoL1 {
     /// @notice Returns true if the contract is paused, and false otherwise.
     /// @return true if paused, false otherwise.
-    function paused() public view virtual returns (bool);
+    function paused() external view returns (bool);
 
     /// @notice Returns information about the last verified block.
     /// @return blockId The last verified block's ID.
@@ -17,6 +17,5 @@ abstract contract TaikoL1 {
     function getLastVerifiedBlock()
         external
         view
-        virtual
         returns (uint64 blockId, bytes32 blockHash, bytes32 stateRoot, uint64 verifiedAt);
 }

--- a/src/adapted-dependencies/TaikoL1.sol
+++ b/src/adapted-dependencies/TaikoL1.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.17;
 
 /// @dev Manual copy of lib/taiko-mono/packages/protocol/contracts/L1/TaikoL1.sol and its dependent structs
+/// from https://github.com/taikoxyz/taiko-mono/tree/protocol-v1.9.0.
 /// This is in order to overcome the conflicting compiler versions between 0.8.17 (OSx) and 0.8.24 (Taiko)
 abstract contract TaikoL1 {
     /// @notice Returns true if the contract is paused, and false otherwise.

--- a/src/adapted-dependencies/TaikoL1.sol
+++ b/src/adapted-dependencies/TaikoL1.sol
@@ -4,97 +4,18 @@ pragma solidity ^0.8.17;
 /// @dev Manual copy of lib/taiko-mono/packages/protocol/contracts/L1/TaikoL1.sol and its dependent structs
 /// This is in order to overcome the conflicting compiler versions between 0.8.17 (OSx) and 0.8.24 (Taiko)
 abstract contract TaikoL1 {
-    TaikoData.State public state;
-
     /// @notice Returns true if the contract is paused, and false otherwise.
     /// @return true if paused, false otherwise.
     function paused() public view virtual returns (bool);
 
-    /// @notice Gets the state variables of the TaikoL1 contract.
-    /// @dev This method can be deleted once node/client stops using it.
-    /// @return State variables stored at SlotA.
-    /// @return State variables stored at SlotB.
-    function getStateVariables() external view virtual returns (TaikoData.SlotA memory, TaikoData.SlotB memory);
-
-    /// @notice Gets the details of a block.
-    /// @param _blockId Index of the block.
-    /// @return blk_ The block.
-    function getBlockV2(uint64 _blockId) external view virtual returns (TaikoData.BlockV2 memory);
-}
-
-library TaikoData {
-    /// @dev Struct containing data required for verifying a block.
-    /// 3 slots used.
-    struct BlockV2 {
-        bytes32 metaHash; // slot 1
-        address assignedProver; // slot 2
-        uint96 livenessBond;
-        uint64 blockId; // slot 3
-        // Before the fork, this field is the L1 timestamp when this block is proposed.
-        // After the fork, this is the timestamp of the L2 block.
-        // In a later fork, we an rename this field to `timestamp`.
-        uint64 proposedAt;
-        // Before the fork, this field is the L1 block number where this block is proposed.
-        // After the fork, this is the L1 block number input for the anchor transaction.
-        // In a later fork, we an rename this field to `anchorBlockId`.
-        uint64 proposedIn;
-        uint24 nextTransitionId;
-        bool livenessBondReturned;
-        // The ID of the transaction that is used to verify this block. However, if
-        // this block is not verified as the last block in a batch, verifiedTransitionId
-        // will remain zero.
-        uint24 verifiedTransitionId;
-    }
-
-    /// @dev Struct representing state transition data.
-    /// 6 slots used.
-    struct TransitionState {
-        bytes32 key; // slot 1, only written/read for the 1st state transition.
-        bytes32 blockHash; // slot 2
-        bytes32 stateRoot; // slot 3
-        address prover; // slot 4
-        uint96 validityBond;
-        address contester; // slot 5
-        uint96 contestBond;
-        uint64 timestamp; // slot 6 (90 bits)
-        uint16 tier;
-        uint8 __reserved1;
-    }
-
-    /// @dev Forge is only able to run coverage in case the contracts by default
-    /// capable of compiling without any optimization (neither optimizer runs,
-    /// no compiling --via-ir flag).
-    /// In order to resolve stack too deep without optimizations, we needed to
-    /// introduce outsourcing vars into structs below.
-    struct SlotA {
-        uint64 genesisHeight;
-        uint64 genesisTimestamp;
-        uint64 lastSyncedBlockId;
-        uint64 lastSynecdAt; // typo!
-    }
-
-    struct SlotB {
-        uint64 numBlocks;
-        uint64 lastVerifiedBlockId;
-        bool provingPaused;
-        uint8 __reservedB1;
-        uint16 __reservedB2;
-        uint32 __reservedB3;
-        uint64 lastUnpausedAt;
-    }
-
-    /// @dev Struct holding the state variables for the {TaikoL1} contract.
-    struct State {
-        // Ring buffer for proposed blocks and a some recent verified blocks.
-        mapping(uint64 => BlockV2) blocks;
-        // Indexing to transition ids (ring buffer not possible)
-        mapping(uint64 => mapping(bytes32 => uint24)) transitionIds;
-        // Ring buffer for transitions
-        mapping(uint64 => mapping(uint32 => TransitionState)) transitions;
-        bytes32 __reserve1; // Used as a ring buffer for Ether deposits
-        SlotA slotA; // slot 5
-        SlotB slotB; // slot 6
-        mapping(address => uint256) bondBalance;
-        uint256[43] __gap;
-    }
+    /// @notice Returns information about the last verified block.
+    /// @return blockId The last verified block's ID.
+    /// @return blockHash The last verified block's blockHash.
+    /// @return stateRoot The last verified block's stateRoot.
+    /// @return verifiedAt The timestamp this block is verified at.
+    function getLastVerifiedBlock()
+        external
+        view
+        virtual
+        returns (uint64 blockId, bytes32 blockHash, bytes32 stateRoot, uint64 verifiedAt);
 }

--- a/src/adapted-dependencies/TaikoL1.sol
+++ b/src/adapted-dependencies/TaikoL1.sol
@@ -8,31 +8,46 @@ abstract contract TaikoL1 {
 
     /// @notice Returns true if the contract is paused, and false otherwise.
     /// @return true if paused, false otherwise.
-    function paused() external view virtual returns (bool);
+    function paused() public view virtual returns (bool);
 
-    /// @notice Gets SlotB
-    /// @return  State variables stored at SlotB.
-    function slotB() public view virtual returns (TaikoData.SlotB memory);
+    /// @notice Gets the state variables of the TaikoL1 contract.
+    /// @dev This method can be deleted once node/client stops using it.
+    /// @return State variables stored at SlotA.
+    /// @return State variables stored at SlotB.
+    function getStateVariables() external view virtual returns (TaikoData.SlotA memory, TaikoData.SlotB memory);
 
-    function getBlock(uint64 _blockId) public view virtual returns (TaikoData.Block memory);
+    /// @notice Gets the details of a block.
+    /// @param _blockId Index of the block.
+    /// @return blk_ The block.
+    function getBlockV2(uint64 _blockId) external view virtual returns (TaikoData.BlockV2 memory);
 }
 
 library TaikoData {
     /// @dev Struct containing data required for verifying a block.
     /// 3 slots used.
-    struct Block {
+    struct BlockV2 {
         bytes32 metaHash; // slot 1
         address assignedProver; // slot 2
         uint96 livenessBond;
         uint64 blockId; // slot 3
-        uint64 proposedAt; // timestamp
-        uint64 proposedIn; // L1 block number, required/used by node/client.
-        uint32 nextTransitionId;
-        uint32 verifiedTransitionId;
+        // Before the fork, this field is the L1 timestamp when this block is proposed.
+        // After the fork, this is the timestamp of the L2 block.
+        // In a later fork, we an rename this field to `timestamp`.
+        uint64 proposedAt;
+        // Before the fork, this field is the L1 block number where this block is proposed.
+        // After the fork, this is the L1 block number input for the anchor transaction.
+        // In a later fork, we an rename this field to `anchorBlockId`.
+        uint64 proposedIn;
+        uint24 nextTransitionId;
+        bool livenessBondReturned;
+        // The ID of the transaction that is used to verify this block. However, if
+        // this block is not verified as the last block in a batch, verifiedTransitionId
+        // will remain zero.
+        uint24 verifiedTransitionId;
     }
 
     /// @dev Struct representing state transition data.
-    /// 10 slots reserved for upgradability, 6 slots used.
+    /// 6 slots used.
     struct TransitionState {
         bytes32 key; // slot 1, only written/read for the 1st state transition.
         bytes32 blockHash; // slot 2
@@ -71,15 +86,15 @@ library TaikoData {
     /// @dev Struct holding the state variables for the {TaikoL1} contract.
     struct State {
         // Ring buffer for proposed blocks and a some recent verified blocks.
-        mapping(uint64 => Block) blocks;
+        mapping(uint64 => BlockV2) blocks;
         // Indexing to transition ids (ring buffer not possible)
-        mapping(uint64 => mapping(bytes32 => uint32)) transitionIds;
+        mapping(uint64 => mapping(bytes32 => uint24)) transitionIds;
         // Ring buffer for transitions
         mapping(uint64 => mapping(uint32 => TransitionState)) transitions;
-        // Ring buffer for Ether deposits
-        bytes32 __reserve1;
+        bytes32 __reserve1; // Used as a ring buffer for Ether deposits
         SlotA slotA; // slot 5
         SlotB slotB; // slot 6
-        uint256[44] __gap;
+        mapping(address => uint256) bondBalance;
+        uint256[43] __gap;
     }
 }

--- a/src/setup/OptimisticTokenVotingPluginSetup.sol
+++ b/src/setup/OptimisticTokenVotingPluginSetup.sol
@@ -18,7 +18,7 @@ import {IGovernanceWrappedERC20} from "@aragon/osx/token/ERC20/governance/IGover
 import {OptimisticTokenVotingPlugin} from "../OptimisticTokenVotingPlugin.sol";
 import {StandardProposalCondition} from "../conditions/StandardProposalCondition.sol";
 import {IERC165} from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
-import {TaikoL1} from "../adapted-dependencies/TaikoL1.sol";
+import {ITaikoL1} from "../adapted-dependencies/ITaikoL1.sol";
 
 /// @title OptimisticTokenVotingPluginSetup
 /// @author Aragon Association - 2022-2023

--- a/test/EmergencyMultisigPluginSetup.t.sol
+++ b/test/EmergencyMultisigPluginSetup.t.sol
@@ -15,7 +15,7 @@ import {IPluginSetup} from "@aragon/osx/framework/plugin/setup/PluginSetup.sol";
 import {PermissionLib} from "@aragon/osx/core/permission/PermissionLib.sol";
 import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
 import {ERC20Mock} from "./mocks/ERC20Mock.sol";
-import {TaikoL1} from "../src/adapted-dependencies/TaikoL1.sol";
+import {ITaikoL1} from "../src/adapted-dependencies/ITaikoL1.sol";
 
 contract EmergencyMultisigPluginSetupTest is Test {
     EmergencyMultisigPluginSetup public pluginSetup;

--- a/test/MultisigPluginSetup.t.sol
+++ b/test/MultisigPluginSetup.t.sol
@@ -14,7 +14,7 @@ import {IPluginSetup} from "@aragon/osx/framework/plugin/setup/PluginSetup.sol";
 import {PermissionLib} from "@aragon/osx/core/permission/PermissionLib.sol";
 import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
 import {ERC20Mock} from "./mocks/ERC20Mock.sol";
-import {TaikoL1} from "../src/adapted-dependencies/TaikoL1.sol";
+import {ITaikoL1} from "../src/adapted-dependencies/ITaikoL1.sol";
 
 contract MultisigPluginSetupTest is Test {
     MultisigPluginSetup public pluginSetup;

--- a/test/OptimisticTokenVotingPlugin.t.sol
+++ b/test/OptimisticTokenVotingPlugin.t.sol
@@ -13,7 +13,7 @@ import {IMembership} from "@aragon/osx/core/plugin/membership/IMembership.sol";
 import {RATIO_BASE, RatioOutOfBounds} from "@aragon/osx/plugins/utils/Ratio.sol";
 import {DaoUnauthorized} from "@aragon/osx/core/utils/auth.sol";
 import {GovernanceERC20Mock} from "./mocks/GovernanceERC20Mock.sol";
-import {TaikoL1} from "../src/adapted-dependencies/TaikoL1.sol";
+import {ITaikoL1} from "../src/adapted-dependencies/ITaikoL1.sol";
 import {IERC165Upgradeable} from "@openzeppelin/contracts-upgradeable/utils/introspection/IERC165Upgradeable.sol";
 import {IERC1822ProxiableUpgradeable} from
     "@openzeppelin/contracts-upgradeable/interfaces/draft-IERC1822Upgradeable.sol";
@@ -25,7 +25,7 @@ contract OptimisticTokenVotingPluginTest is AragonTest {
     DAO dao;
     OptimisticTokenVotingPlugin optimisticPlugin;
     GovernanceERC20Mock votingToken;
-    TaikoL1 taikoL1;
+    ITaikoL1 taikoL1;
 
     // Events from external contracts
     event Initialized(uint8 version);
@@ -261,7 +261,7 @@ contract OptimisticTokenVotingPluginTest is AragonTest {
         assertEq(address(optimisticPlugin.taikoBridge()), address(taikoBridge), "Incorrect taikoBridge");
 
         // Different taikoL1 contract
-        taikoL1 = TaikoL1(address(0x1234));
+        taikoL1 = ITaikoL1(address(0x1234));
         optimisticPlugin = OptimisticTokenVotingPlugin(
             createProxyAndCall(
                 address(OPTIMISTIC_BASE),

--- a/test/OptimisticTokenVotingPluginSetup.t.sol
+++ b/test/OptimisticTokenVotingPluginSetup.t.sol
@@ -14,7 +14,7 @@ import {IPluginSetup} from "@aragon/osx/framework/plugin/setup/PluginSetup.sol";
 import {PermissionLib} from "@aragon/osx/core/permission/PermissionLib.sol";
 import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
 import {ERC20Mock} from "./mocks/ERC20Mock.sol";
-import {TaikoL1} from "../src/adapted-dependencies/TaikoL1.sol";
+import {ITaikoL1} from "../src/adapted-dependencies/ITaikoL1.sol";
 
 contract OptimisticTokenVotingPluginSetupTest is Test {
     OptimisticTokenVotingPluginSetup public pluginSetup;
@@ -27,7 +27,7 @@ contract OptimisticTokenVotingPluginSetupTest is Test {
     OptimisticTokenVotingPlugin.OptimisticGovernanceSettings votingSettings;
     OptimisticTokenVotingPluginSetup.TokenSettings tokenSettings;
     GovernanceERC20.MintSettings mintSettings;
-    TaikoL1 taikoL1;
+    ITaikoL1 taikoL1;
     address taikoBridge;
     uint64 stdProposalMinDuration;
     address stdProposer;
@@ -68,7 +68,7 @@ contract OptimisticTokenVotingPluginSetupTest is Test {
             symbol: "wTK"
         });
         mintSettings = GovernanceERC20.MintSettings({receivers: new address[](0), amounts: new uint256[](0)});
-        taikoL1 = TaikoL1(address(0x66666666));
+        taikoL1 = ITaikoL1(address(0x66666666));
         taikoBridge = address(0x55555555);
         stdProposalMinDuration = 10 days;
         stdProposer = address(0x1234567890);

--- a/test/base/AragonTest.sol
+++ b/test/base/AragonTest.sol
@@ -10,7 +10,7 @@ import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.s
 import {createProxyAndCall} from "../../src/helpers/proxy.sol";
 import {RATIO_BASE} from "@aragon/osx/plugins/utils/Ratio.sol";
 import {TaikoL1Mock, TaikoL1PausedMock, TaikoL1WithOldLastBlock} from "../mocks/TaikoL1Mock.sol";
-import {TaikoL1} from "../../src/adapted-dependencies/TaikoL1.sol";
+import {ITaikoL1} from "../../src/adapted-dependencies/ITaikoL1.sol";
 import {ALICE_ADDRESS, BOB_ADDRESS, CAROL_ADDRESS, DAVID_ADDRESS, TAIKO_BRIDGE_ADDRESS} from "../constants.sol";
 import {Test} from "forge-std/Test.sol";
 

--- a/test/helpers/DaoBuilder.sol
+++ b/test/helpers/DaoBuilder.sol
@@ -9,7 +9,7 @@ import {OptimisticTokenVotingPlugin} from "../../src/OptimisticTokenVotingPlugin
 import {createProxyAndCall} from "../../src/helpers/proxy.sol";
 import {RATIO_BASE} from "@aragon/osx/plugins/utils/Ratio.sol";
 import {TaikoL1Mock, TaikoL1PausedMock, TaikoL1WithOldLastBlock, TaikoL1Incompatible} from "../mocks/TaikoL1Mock.sol";
-import {TaikoL1} from "../../src/adapted-dependencies/TaikoL1.sol";
+import {ITaikoL1} from "../../src/adapted-dependencies/ITaikoL1.sol";
 import {ALICE_ADDRESS, TAIKO_BRIDGE_ADDRESS} from "../constants.sol";
 import {GovernanceERC20Mock} from "../mocks/GovernanceERC20Mock.sol";
 
@@ -162,7 +162,7 @@ contract DaoBuilder is Test {
             Multisig multisig,
             EmergencyMultisig emergencyMultisig,
             GovernanceERC20Mock votingToken,
-            TaikoL1 taikoL1
+            ITaikoL1 taikoL1
         )
     {
         // Deploy the DAO with `this` as root
@@ -193,7 +193,7 @@ contract DaoBuilder is Test {
         } else if (taikoL1Status == TaikoL1Status.OutOfSync) {
             taikoL1 = new TaikoL1WithOldLastBlock();
         } else {
-            taikoL1 = TaikoL1(address(new TaikoL1Incompatible()));
+            taikoL1 = ITaikoL1(address(new TaikoL1Incompatible()));
         }
 
         {

--- a/test/mocks/TaikoL1Mock.sol
+++ b/test/mocks/TaikoL1Mock.sol
@@ -15,9 +15,9 @@ contract TaikoL1Mock is TaikoL1 {
         override
         returns (uint64 blockId, bytes32 blockHash, bytes32 stateRoot, uint64 verifiedAt)
     {
-        blockId = 0; // irrelevant
-        blockHash = bytes32(0); // irrelevant
-        stateRoot = bytes32(0); // irrelevant
+        blockId;
+        blockHash;
+        stateRoot;
         verifiedAt = uint64(block.timestamp) - 1;
     }
 }
@@ -34,9 +34,9 @@ contract TaikoL1PausedMock is TaikoL1 {
         override
         returns (uint64 blockId, bytes32 blockHash, bytes32 stateRoot, uint64 verifiedAt)
     {
-        blockId = 0; // irrelevant
-        blockHash = bytes32(0); // irrelevant
-        stateRoot = bytes32(0); // irrelevant
+        blockId;
+        blockHash;
+        stateRoot;
         verifiedAt = 0;
     }
 }
@@ -52,9 +52,9 @@ contract TaikoL1WithOldLastBlock is TaikoL1 {
         override
         returns (uint64 blockId, bytes32 blockHash, bytes32 stateRoot, uint64 verifiedAt)
     {
-        blockId = 0; // irrelevant
-        blockHash = bytes32(0); // irrelevant
-        stateRoot = bytes32(0); // irrelevant
+        blockId;
+        blockHash;
+        stateRoot;
         verifiedAt = 1;
     }
 }

--- a/test/mocks/TaikoL1Mock.sol
+++ b/test/mocks/TaikoL1Mock.sol
@@ -5,42 +5,61 @@ import {TaikoL1, TaikoData} from "../../src/adapted-dependencies/TaikoL1.sol";
 
 /// @dev Returns an unpaused TaikoL1 with any given block proposed 1 second ago
 contract TaikoL1Mock is TaikoL1 {
-    function paused() external pure override returns (bool) {
+    function paused() public pure override returns (bool) {
         return false;
     }
 
-    function slotB() public pure override returns (TaikoData.SlotB memory result) {
-        result.numBlocks = 90;
+    function getStateVariables()
+        public
+        pure
+        override
+        returns (TaikoData.SlotA memory slotA, TaikoData.SlotB memory slotB)
+    {
+        slotA;
+        slotB.numBlocks = 90;
     }
 
-    function getBlock(uint64 _blockId) public view override returns (TaikoData.Block memory result) {
-        _blockId;
-        result.proposedAt = uint64(block.timestamp) - 1;
+    function getBlockV2(uint64) public view override returns (TaikoData.BlockV2 memory blk) {
+        blk.proposedAt = uint64(block.timestamp) - 1;
     }
 }
 
 /// @dev Returns a paused TaikoL1
 contract TaikoL1PausedMock is TaikoL1 {
-    function paused() external pure override returns (bool) {
+    function paused() public pure override returns (bool) {
         return true;
     }
 
-    function slotB() public view override returns (TaikoData.SlotB memory result) {}
-    function getBlock(uint64 _blockId) public view override returns (TaikoData.Block memory) {}
+    function getStateVariables()
+        public
+        pure
+        override
+        returns (TaikoData.SlotA memory slotA, TaikoData.SlotB memory slotB)
+    {
+        slotA;
+        slotB.numBlocks = 1;
+    }
+
+    function getBlockV2(uint64) public view override returns (TaikoData.BlockV2 memory) {}
 }
 
 contract TaikoL1WithOldLastBlock is TaikoL1 {
-    function paused() external pure override returns (bool) {
+    function paused() public pure override returns (bool) {
         return false;
     }
 
-    function slotB() public pure override returns (TaikoData.SlotB memory result) {
-        result.numBlocks = 1;
+    function getStateVariables()
+        public
+        pure
+        override
+        returns (TaikoData.SlotA memory slotA, TaikoData.SlotB memory slotB)
+    {
+        slotA;
+        slotB.numBlocks = 1;
     }
 
-    function getBlock(uint64 _blockId) public pure override returns (TaikoData.Block memory result) {
-        _blockId;
-        result.proposedAt = 1;
+    function getBlockV2(uint64) public pure override returns (TaikoData.BlockV2 memory blk) {
+        blk.proposedAt = 1;
     }
 }
 

--- a/test/mocks/TaikoL1Mock.sol
+++ b/test/mocks/TaikoL1Mock.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity >=0.8.17 <0.9.0;
 
-import {TaikoL1} from "../../src/adapted-dependencies/TaikoL1.sol";
+import {ITaikoL1} from "../../src/adapted-dependencies/ITaikoL1.sol";
 
 /// @dev Returns an unpaused TaikoL1 with any given block proposed 1 second ago
-contract TaikoL1Mock is TaikoL1 {
+contract TaikoL1Mock is ITaikoL1 {
     function paused() public pure override returns (bool) {
         return false;
     }
@@ -23,7 +23,7 @@ contract TaikoL1Mock is TaikoL1 {
 }
 
 /// @dev Returns a paused TaikoL1
-contract TaikoL1PausedMock is TaikoL1 {
+contract TaikoL1PausedMock is ITaikoL1 {
     function paused() public pure override returns (bool) {
         return true;
     }
@@ -41,7 +41,7 @@ contract TaikoL1PausedMock is TaikoL1 {
     }
 }
 
-contract TaikoL1WithOldLastBlock is TaikoL1 {
+contract TaikoL1WithOldLastBlock is ITaikoL1 {
     function paused() public pure override returns (bool) {
         return false;
     }

--- a/test/mocks/TaikoL1Mock.sol
+++ b/test/mocks/TaikoL1Mock.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity >=0.8.17 <0.9.0;
 
-import {TaikoL1, TaikoData} from "../../src/adapted-dependencies/TaikoL1.sol";
+import {TaikoL1} from "../../src/adapted-dependencies/TaikoL1.sol";
 
 /// @dev Returns an unpaused TaikoL1 with any given block proposed 1 second ago
 contract TaikoL1Mock is TaikoL1 {
@@ -9,18 +9,16 @@ contract TaikoL1Mock is TaikoL1 {
         return false;
     }
 
-    function getStateVariables()
-        public
-        pure
+    function getLastVerifiedBlock()
+        external
+        view
         override
-        returns (TaikoData.SlotA memory slotA, TaikoData.SlotB memory slotB)
+        returns (uint64 blockId, bytes32 blockHash, bytes32 stateRoot, uint64 verifiedAt)
     {
-        slotA;
-        slotB.numBlocks = 90;
-    }
-
-    function getBlockV2(uint64) public view override returns (TaikoData.BlockV2 memory blk) {
-        blk.proposedAt = uint64(block.timestamp) - 1;
+        blockId = 0; // irrelevant
+        blockHash = bytes32(0); // irrelevant
+        stateRoot = bytes32(0); // irrelevant
+        verifiedAt = uint64(block.timestamp) - 1;
     }
 }
 
@@ -30,17 +28,17 @@ contract TaikoL1PausedMock is TaikoL1 {
         return true;
     }
 
-    function getStateVariables()
-        public
+    function getLastVerifiedBlock()
+        external
         pure
         override
-        returns (TaikoData.SlotA memory slotA, TaikoData.SlotB memory slotB)
+        returns (uint64 blockId, bytes32 blockHash, bytes32 stateRoot, uint64 verifiedAt)
     {
-        slotA;
-        slotB.numBlocks = 1;
+        blockId = 0; // irrelevant
+        blockHash = bytes32(0); // irrelevant
+        stateRoot = bytes32(0); // irrelevant
+        verifiedAt = 0;
     }
-
-    function getBlockV2(uint64) public view override returns (TaikoData.BlockV2 memory) {}
 }
 
 contract TaikoL1WithOldLastBlock is TaikoL1 {
@@ -48,18 +46,16 @@ contract TaikoL1WithOldLastBlock is TaikoL1 {
         return false;
     }
 
-    function getStateVariables()
-        public
+    function getLastVerifiedBlock()
+        external
         pure
         override
-        returns (TaikoData.SlotA memory slotA, TaikoData.SlotB memory slotB)
+        returns (uint64 blockId, bytes32 blockHash, bytes32 stateRoot, uint64 verifiedAt)
     {
-        slotA;
-        slotB.numBlocks = 1;
-    }
-
-    function getBlockV2(uint64) public pure override returns (TaikoData.BlockV2 memory blk) {
-        blk.proposedAt = 1;
+        blockId = 0; // irrelevant
+        blockHash = bytes32(0); // irrelevant
+        stateRoot = bytes32(0); // irrelevant
+        verifiedAt = 1;
     }
 }
 

--- a/test/mocks/VetoToken.sol
+++ b/test/mocks/VetoToken.sol
@@ -12,11 +12,7 @@ contract VetoToken is ERC20, ERC20Permit, ERC20Votes {
 
     // The following functions are overrides required by Solidity.
 
-    function _afterTokenTransfer(
-        address from,
-        address to,
-        uint256 amount
-    ) internal override(ERC20, ERC20Votes) {
+    function _afterTokenTransfer(address from, address to, uint256 amount) internal override(ERC20, ERC20Votes) {
         super._afterTokenTransfer(from, to, amount);
     }
 
@@ -28,17 +24,11 @@ contract VetoToken is ERC20, ERC20Permit, ERC20Votes {
         _burn(account, amount);
     }
 
-    function _mint(
-        address to,
-        uint256 amount
-    ) internal override(ERC20, ERC20Votes) {
+    function _mint(address to, uint256 amount) internal override(ERC20, ERC20Votes) {
         super._mint(to, amount);
     }
 
-    function _burn(
-        address account,
-        uint256 amount
-    ) internal override(ERC20, ERC20Votes) {
+    function _burn(address account, uint256 amount) internal override(ERC20, ERC20Votes) {
         super._burn(account, amount);
     }
 }


### PR DESCRIPTION
Updated `TaikoL1.sol` to use the most up-to-date code from https://github.com/taikoxyz/taiko-mono/tree/protocol-v1.9.0 and  use `getLastVerifiedBlock` to fetch the last block verification timestamp.
