### PR TITLE
Exit window

### DIFF
--- a/src/interfaces/IOptimisticTokenVoting.sol
+++ b/src/interfaces/IOptimisticTokenVoting.sol
@@ -43,7 +43,7 @@ interface IOptimisticTokenVoting {
     /// @param _metadata The metadata of the proposal.
     /// @param _actions The actions that will be executed after the proposal passes.
     /// @param _allowFailureMap Allows proposal to succeed even if an action reverts. Uses bitmap representation. If the bit at index `x` is 1, the tx succeeds even if the action at `x` failed. Passing 0 will be treated as atomic execution.
-    /// @param _duration The amount of seconds to allow token holders to veto.
+    /// @param _duration The amount of seconds to allow for token holders to veto. NOTE: If the supplied value is zero, the proposal will be treated as an emergency one.
     /// @return proposalId The ID of the proposal.
     function createProposal(
         bytes calldata _metadata,

--- a/test/Multisig.t.sol
+++ b/test/Multisig.t.sol
@@ -1320,9 +1320,6 @@ contract MultisigTest is AragonTest {
             assertEq(multisig.canApprove(pid, randomWallet), false, "Should be false");
         }
 
-        // static ko
-        assertEq(multisig.canApprove(pid, randomWallet), false, "Should be false");
-
         // static ok
         assertEq(multisig.canApprove(pid, alice), true, "Should be true");
     }

--- a/test/OptimisticTokenVotingPlugin.t.sol
+++ b/test/OptimisticTokenVotingPlugin.t.sol
@@ -1722,6 +1722,24 @@ contract OptimisticTokenVotingPluginTest is AragonTest {
         assertEq(parameters.unavailableL2, true, "unavailableL2 should be true");
     }
 
+    function test_CanExecuteReturnsTrueOnDurationZero_WithoutL2GracePeriodOrExitWindow() public {
+        (, optimisticPlugin,,,,) = builder.withMinDuration(0).build();
+
+        IDAO.Action[] memory actions = new IDAO.Action[](0);
+        uint256 proposalId = optimisticPlugin.createProposal("ipfs://", actions, 0, 0 days);
+
+        assertEq(optimisticPlugin.canExecute(proposalId), false, "The proposal should not be executable");
+
+        // Emergency: already executed
+
+        (bool open, bool executed, OptimisticTokenVotingPlugin.ProposalParameters memory parameters,,,,) =
+            optimisticPlugin.getProposal(proposalId);
+
+        assertEq(open, false, "Open should be false");
+        assertEq(executed, true, "Executed should be true");
+        assertEq(parameters.unavailableL2, true, "unavailableL2 should be true");
+    }
+
     function test_CanExecuteReturnsTrueOtherwise() public {
         IDAO.Action[] memory actions = new IDAO.Action[](0);
         uint256 proposalId = optimisticPlugin.createProposal("ipfs://", actions, 0, 4 days);


### PR DESCRIPTION
Adding an additional delay of 7 days for token holders who want to exit before a proposal is executed.