### PR TITLE
Add governance parameter validation checks in TaikoDaoFactory.sol

### DIFF
--- a/test/integration/TaikoDaoFactory.t.sol
+++ b/test/integration/TaikoDaoFactory.t.sol
@@ -187,7 +187,7 @@ contract TaikoDaoFactoryTest is AragonTest {
             minVetoRatio: 456_000, // uint32
             minStdProposalDuration: 14 days, // uint32
             minStdApprovals: 4, // uint16
-            minEmergencyApprovals: 27, // uint16
+            minEmergencyApprovals: 8, // uint16
             // OSx contracts
             osxDaoFactory: address(daoFactory), // DaoFactory
             pluginSetupProcessor: PluginSetupProcessor(address(psp)), // PluginSetupProcessor
@@ -961,7 +961,7 @@ contract TaikoDaoFactoryTest is AragonTest {
         );
         assertEq(hasPerm, true, "Incorrect hasPermission");
 
-         hasPerm = deployment.dao.hasPermission(
+        hasPerm = deployment.dao.hasPermission(
             address(deployment.emergencyMultisigPluginRepo),
             address(deployment.dao),
             deployment.emergencyMultisigPluginRepo.MAINTAINER_PERMISSION_ID(),
@@ -969,7 +969,7 @@ contract TaikoDaoFactoryTest is AragonTest {
         );
         assertEq(hasPerm, true, "Incorrect hasPermission");
 
-         hasPerm = deployment.dao.hasPermission(
+        hasPerm = deployment.dao.hasPermission(
             address(deployment.optimisticTokenVotingPluginRepo),
             address(deployment.dao),
             deployment.optimisticTokenVotingPluginRepo.MAINTAINER_PERMISSION_ID(),


### PR DESCRIPTION
This PR addresses the HAL-02 ("Missing Validation for Governance Parameter Constraints") from the Halborn audit report. Specifically, it adds the following input validations at the factory level to ensure deployments use consistent and valid governance parameters:

- Quorum Threshold Checks:
Ensure ```minStdApprovals``` and ```minEmergencyApprovals``` are greater than zero and do not exceed the multisig member count (redundant checks complementing existing plugin validations).

- L2 Address Checks:
When `skipL2` is false, validate that `taikoL1ContractAddress` and `taikoBridgeAddress` are non-zero, preventing faulty cross-chain governance configurations.

- Sanity Checks on Ratios and Duration:
Validate `minVetoRatio` falls within [0, `RATIO_BASE`].
Validate that `minStdProposalDuration` is non-zero and within practical limits (e.g., maximum 180 days).

This comprehensive validation improves the DAO factory's robustness by catching invalid configurations early during deployment